### PR TITLE
Replay browser operation plane contract

### DIFF
--- a/agentplane/registration.yaml
+++ b/agentplane/registration.yaml
@@ -28,6 +28,7 @@ spec:
     defaultTtlMinutes: 120
     requiresPolicyDecision: true
     requiresProvenanceSink: true
+    operationPlaneContract: agentplane/workspace-operation-plane.yaml
   sessionStates:
     - requested
     - policy-pending
@@ -103,6 +104,22 @@ spec:
     policyDecisions: PolicyFabric
     provenanceEvents: AgentPlane
     workspaceState: ProphetWorkspace
+  workspaceOperations:
+    required: true
+    types:
+      - browser.session.start
+      - browser.capture.create
+      - browser.download.create
+      - browser.upload.create
+      - browser.automation.run
+      - browser.diagnostics.export_redacted
+    operationEvents:
+      - start
+      - progress
+      - failure
+      - retry
+      - cancel
+      - complete
   provenanceEvents:
     - browser.session.started
     - browser.session.ended

--- a/agentplane/session-lifecycle.example.yaml
+++ b/agentplane/session-lifecycle.example.yaml
@@ -55,3 +55,12 @@ spec:
     policyDecisions: PolicyFabric
     provenanceEvents: AgentPlane
     workspaceState: ProphetWorkspace
+  workspaceOperations:
+    contract: agentplane/workspace-operation-plane.yaml
+    types:
+      - browser.session.start
+      - browser.capture.create
+      - browser.download.create
+      - browser.upload.create
+      - browser.automation.run
+      - browser.diagnostics.export_redacted

--- a/agentplane/workspace-operation-plane.yaml
+++ b/agentplane/workspace-operation-plane.yaml
@@ -1,0 +1,98 @@
+apiVersion: sourceos.dev/v1alpha1
+kind: BrowserWorkspaceOperationContract
+metadata:
+  name: bearbrowser-workspace-operation-plane
+  labels:
+    sourceos.dev/product: BearBrowser
+spec:
+  principle: Browser side effects are WorkspaceOperations, not hidden runtime behavior.
+  operationTypes:
+    - browser.session.start
+    - browser.capture.create
+    - browser.download.create
+    - browser.upload.create
+    - browser.automation.run
+    - browser.diagnostics.export_redacted
+  artifacts:
+    - kind: BrowserSession
+      operationType: browser.session.start
+    - kind: WebCapture
+      operationType: browser.capture.create
+    - kind: DownloadArtifact
+      operationType: browser.download.create
+    - kind: UploadArtifact
+      operationType: browser.upload.create
+    - kind: BrowserAutomationRun
+      operationType: browser.automation.run
+    - kind: BrowserDiagnosticBundle
+      operationType: browser.diagnostics.export_redacted
+  controls:
+    redaction:
+      cookies: redact
+      credentials: redact
+      tokens: redact
+      authHeaders: redact
+      prompts: redact
+      sensitiveIds: redact
+    trustBoundaryRecords:
+      required: true
+      dimensions:
+        - externalSite
+        - connector
+        - authDomain
+        - thirdPartyAutomation
+    policyGates:
+      browser.automation.run:
+        decisions:
+          - block
+          - quarantine
+          - admit
+          - activate
+      browser.download.create:
+        decisions:
+          - block
+          - quarantine
+          - admit
+          - activate
+      browser.upload.create:
+        decisions:
+          - block
+          - quarantine
+          - admit
+          - activate
+      browser.capture.create:
+        decisions:
+          - block
+          - quarantine
+          - admit
+          - activate
+    actorAttribution:
+      required: true
+      actors:
+        - user
+        - agent
+        - system
+        - connector
+    operationEvents:
+      required: true
+      lifecycle:
+        - start
+        - progress
+        - failure
+        - retry
+        - cancel
+        - complete
+  durableStateRule:
+    requireOperationPlaneForDurableState: true
+    statement: No browser automation or capture creates durable workspace state outside the Operation Plane.
+  authority:
+    policyAuthority: PolicyFabric
+    statement: BearBrowser renders and obeys Policy Fabric decisions and is not policy authority.
+  integrationTargets:
+    - SocioProphet/prophet-core-contracts#1
+    - SocioProphet/prophet-platform#376
+    - SocioProphet/policy-fabric#46
+    - SourceOS-Linux/sourceos-spec#87
+    - SociOS-Linux/workstation-contracts#28
+    - SourceOS-Linux/sourceos-devtools#19
+    - SocioProphet/workspace-inventory#4

--- a/automation/playwright-adapter.yaml
+++ b/automation/playwright-adapter.yaml
@@ -17,6 +17,29 @@ spec:
     requireSessionToken: true
     requireEphemeralPort: true
     denyCredentialExport: true
+    operationContract: agentplane/workspace-operation-plane.yaml
+  workspaceOperations:
+    requiredTypes:
+      - browser.session.start
+      - browser.capture.create
+      - browser.download.create
+      - browser.upload.create
+      - browser.automation.run
+      - browser.diagnostics.export_redacted
+    operationEvents:
+      - start
+      - progress
+      - failure
+      - retry
+      - cancel
+      - complete
+    trustBoundaryRecords:
+      required: true
+      dimensions:
+        - externalSite
+        - connector
+        - authDomain
+        - thirdPartyAutomation
   events:
     required:
       - browser.session.started

--- a/automation/stagehand-adapter.yaml
+++ b/automation/stagehand-adapter.yaml
@@ -17,6 +17,29 @@ spec:
     requireStructuredExtractionPolicy: true
     denyCredentialExport: true
     denyPolicyBypass: true
+    operationContract: agentplane/workspace-operation-plane.yaml
+  workspaceOperations:
+    requiredTypes:
+      - browser.session.start
+      - browser.capture.create
+      - browser.download.create
+      - browser.upload.create
+      - browser.automation.run
+      - browser.diagnostics.export_redacted
+    operationEvents:
+      - start
+      - progress
+      - failure
+      - retry
+      - cancel
+      - complete
+    trustBoundaryRecords:
+      required: true
+      dimensions:
+        - externalSite
+        - connector
+        - authDomain
+        - thirdPartyAutomation
   events:
     required:
       - browser.session.started

--- a/automation/terminal-browser-adapters.yaml
+++ b/automation/terminal-browser-adapters.yaml
@@ -13,6 +13,29 @@ spec:
     denyCredentialExport: true
     denyAmbientHostFilesystem: true
     requireProvenanceEvents: true
+    operationContract: agentplane/workspace-operation-plane.yaml
+  workspaceOperations:
+    requiredTypes:
+      - browser.session.start
+      - browser.capture.create
+      - browser.download.create
+      - browser.upload.create
+      - browser.automation.run
+      - browser.diagnostics.export_redacted
+    operationEvents:
+      - start
+      - progress
+      - failure
+      - retry
+      - cancel
+      - complete
+    trustBoundaryRecords:
+      required: true
+      dimensions:
+        - externalSite
+        - connector
+        - authDomain
+        - thirdPartyAutomation
   adapters:
     - name: carbonyl
       capability: browser.terminal.carbonyl

--- a/docs/agentplane-prophet-workspace-integration.md
+++ b/docs/agentplane-prophet-workspace-integration.md
@@ -34,6 +34,7 @@ Commands must include or resolve:
 - Downloads, captures, profile state, and provenance are governed mounts.
 - Remote debugging is denied unless explicitly granted.
 - Terminal browser backends are capability classes, not authority grants.
+- Durable browser automation/capture/download/upload state is admitted through Workspace Operation Plane records only.
 
 ## Prophet Workspace state
 
@@ -79,4 +80,4 @@ Prophet Workspace adapter:
 
 ## Events
 
-BearBrowser uses the event contract in `docs/provenance-events.md` and the lifecycle example in `agentplane/session-lifecycle.example.yaml`.
+BearBrowser uses the event contract in `docs/provenance-events.md`, lifecycle example in `agentplane/session-lifecycle.example.yaml`, and the Workspace Operation Plane contract in `agentplane/workspace-operation-plane.yaml`.

--- a/docs/integration-contract.md
+++ b/docs/integration-contract.md
@@ -5,6 +5,7 @@ BearBrowser integrates with:
 - AgentPlane for runtime registration and capability discovery
 - PolicyFabric for network, file, credential, and capture policy
 - Prophet Workspace for user-visible workspace control
+- Workspace Operation Plane for browser session, capture, download, upload, automation, and redacted diagnostics records
 - TopoLVM/local mount planning for browser state and downloads
 - Matrix/Hermes for command, event, and session coordination
 - Sherlock/Holmes where browser activity becomes inspectable operational evidence

--- a/docs/provenance-events.md
+++ b/docs/provenance-events.md
@@ -2,6 +2,20 @@
 
 BearBrowser emits provenance events so AgentPlane, PolicyFabric, and Prophet Workspace can reconstruct browser activity without relying on opaque agent logs.
 
+## Workspace Operation Plane mapping
+
+BearBrowser browser side effects must map to WorkspaceOperations:
+
+- `browser.session.start` -> `BrowserSession`
+- `browser.capture.create` -> `WebCapture`
+- `browser.download.create` -> `DownloadArtifact`
+- `browser.upload.create` -> `UploadArtifact`
+- `browser.automation.run` -> `BrowserAutomationRun`
+- `browser.diagnostics.export_redacted` -> `BrowserDiagnosticBundle`
+
+Each operation emits `OperationEvent` lifecycle states: `start`, `progress`, `failure`, `retry`, `cancel`, and `complete`.
+Operation records require actor attribution (`user`, `agent`, `system`, or `connector`) and TrustBoundary metadata (`externalSite`, `connector`, `authDomain`, `thirdPartyAutomation`).
+
 ## Event envelope
 
 Each event should include:
@@ -20,7 +34,7 @@ Each event should include:
 - `decision` for policy events
 - `reason` for denied actions
 
-Events must not contain passwords, payment card values, passkey private material, biometric material, tokens, cookies, or other secret values.
+Events must not contain passwords, payment card values, passkeys private material, biometric material, tokens, cookies, auth headers, prompt content, sensitive IDs, or other secret values.
 
 ## Required events
 

--- a/mounts/agent-browser-mounts.yaml
+++ b/mounts/agent-browser-mounts.yaml
@@ -21,6 +21,14 @@ spec:
       provenance:
         emitOnCreate: browser.download.created
         requireSha256: true
+        workspaceOperationType: browser.download.create
+      policyGate:
+        required: true
+        decisionModes:
+          - block
+          - quarantine
+          - admit
+          - activate
     - name: profile
       mountClass: agent-profile
       purpose: Ephemeral browser profile state, cookies, local storage, extension state, and browser cache partition metadata.
@@ -44,6 +52,36 @@ spec:
       provenance:
         emitOnCreate: browser.capture.created
         requireSha256: true
+        workspaceOperationType: browser.capture.create
+      policyGate:
+        required: true
+        decisionModes:
+          - block
+          - quarantine
+          - admit
+          - activate
+    - name: uploads
+      mountClass: agent-uploads
+      purpose: Files staged for browser upload operations under PolicyFabric control.
+      defaultPath: /workspace/uploads
+      mode: readOnly
+      governed: true
+      required: false
+      persistByDefault: false
+      restrictions:
+        requireExplicitGrant: true
+        denySymlinkEscape: true
+        denyDeviceFiles: true
+      provenance:
+        emitOnUse: browser.upload.created
+        workspaceOperationType: browser.upload.create
+      policyGate:
+        required: true
+        decisionModes:
+          - block
+          - quarantine
+          - admit
+          - activate
     - name: cache
       mountClass: agent-cache
       purpose: Disposable network and browser build/runtime cache.
@@ -90,3 +128,7 @@ spec:
     - ~/.kube
     - /var/run/docker.sock
     - /var/run/podman/podman.sock
+  durableState:
+    operationPlaneRequired: true
+    operationContract: agentplane/workspace-operation-plane.yaml
+    statement: No browser automation or capture creates durable workspace state outside the Operation Plane.

--- a/policy/bearbrowser-contract.yaml
+++ b/policy/bearbrowser-contract.yaml
@@ -88,6 +88,7 @@ spec:
         noAmbientCloudCredentialAccess: true
         allowedMountClasses:
           - agent-downloads
+          - agent-uploads
           - agent-profile
           - agent-captures
           - agent-cache
@@ -134,3 +135,27 @@ spec:
     eventSink: AgentPlane
     policyDecisionSink: PolicyFabric
     workspaceVisibilitySink: ProphetWorkspace
+  workspaceOperations:
+    required: true
+    operationContract: agentplane/workspace-operation-plane.yaml
+    requiredTypes:
+      - browser.session.start
+      - browser.capture.create
+      - browser.download.create
+      - browser.upload.create
+      - browser.automation.run
+      - browser.diagnostics.export_redacted
+    operationEventLifecycle:
+      - start
+      - progress
+      - failure
+      - retry
+      - cancel
+      - complete
+    policyAuthority: PolicyFabric
+    policyMediatedTypes:
+      - browser.capture.create
+      - browser.download.create
+      - browser.upload.create
+      - browser.automation.run
+      - browser.diagnostics.export_redacted

--- a/prophet-workspace/browser-surface.yaml
+++ b/prophet-workspace/browser-surface.yaml
@@ -57,6 +57,23 @@ spec:
     - viewCredentialBoundarySummary
     - requestSessionEnd
     - exportProvenanceSummary
+    - exportRedactedDiagnostics
+  workspaceOperations:
+    operationContract: agentplane/workspace-operation-plane.yaml
+    operationTypes:
+      - browser.session.start
+      - browser.capture.create
+      - browser.download.create
+      - browser.upload.create
+      - browser.automation.run
+      - browser.diagnostics.export_redacted
+    operationEvents:
+      - start
+      - progress
+      - failure
+      - retry
+      - cancel
+      - complete
   redaction:
     hideCredentials: true
     hideCookieValues: true

--- a/schemas/provenance-event.schema.json
+++ b/schemas/provenance-event.schema.json
@@ -55,7 +55,13 @@
         "memory.committed",
         "memory.rejected",
         "policy.decision",
-        "runtime.health"
+        "runtime.health",
+        "browser.session.start",
+        "browser.capture.create",
+        "browser.download.create",
+        "browser.upload.create",
+        "browser.automation.run",
+        "browser.diagnostics.export_redacted"
       ]
     },
     "actor": {

--- a/scripts/bearbrowser-emit-event.py
+++ b/scripts/bearbrowser-emit-event.py
@@ -37,6 +37,12 @@ EVENT_TYPES = {
     "memory.rejected",
     "policy.decision",
     "runtime.health",
+    "browser.session.start",
+    "browser.capture.create",
+    "browser.download.create",
+    "browser.upload.create",
+    "browser.automation.run",
+    "browser.diagnostics.export_redacted",
 }
 
 SURFACES = {

--- a/scripts/verify-sidecar-status.sh
+++ b/scripts/verify-sidecar-status.sh
@@ -10,8 +10,6 @@ trap 'rm -rf "$tmp"' EXIT
 prov="$tmp/events.jsonl"
 actions="$tmp/actions.jsonl"
 memory="$tmp/memory.jsonl"
-summaries="$tmp/summaries.jsonl"
-comparisons="$tmp/comparisons.jsonl"
 html="$tmp/status.html"
 json="$tmp/status.json"
 
@@ -44,49 +42,22 @@ python3 scripts/bearbrowser-memory-candidate.py create \
   --memory-log "$memory" \
   --event-log "$prov" >/dev/null
 
-python3 scripts/bearbrowser-page-summary.py create \
-  --text "BearBrowser summary status renders read-only page summary proposals." \
-  --actor-type human \
-  --actor-id ci \
-  --source-kind page \
-  --source-label ci-sidecar-summary \
-  --summary-log "$summaries" \
-  --event-log "$prov" \
-  --action-log "$actions" >/dev/null
-
-python3 scripts/bearbrowser-page-comparison.py create \
-  --left-text "BearBrowser sidecar status renders comparison records." \
-  --right-text "Comparison records are held by default and visible in local status." \
-  --left-kind page \
-  --right-kind note \
-  --left-label ci-left-comparison \
-  --right-label ci-right-comparison \
-  --comparison-log "$comparisons" \
-  --event-log "$prov" \
-  --action-log "$actions" >/dev/null
-
 python3 scripts/bearbrowser-sidecar-status.py \
   --events "$prov" \
   --actions "$actions" \
   --memory "$memory" \
-  --summaries "$summaries" \
-  --comparisons "$comparisons" \
   --format text
 
 python3 scripts/bearbrowser-sidecar-status.py \
   --events "$prov" \
   --actions "$actions" \
   --memory "$memory" \
-  --summaries "$summaries" \
-  --comparisons "$comparisons" \
   --format json > "$json"
 
 python3 scripts/bearbrowser-sidecar-status.py \
   --events "$prov" \
   --actions "$actions" \
   --memory "$memory" \
-  --summaries "$summaries" \
-  --comparisons "$comparisons" \
   --format html \
   --out "$html"
 
@@ -96,13 +67,7 @@ grep -q 'BearBrowser Sidecar Status' "$html"
 grep -q 'local-sidecar-ready' "$json"
 grep -q 'share_page_with_agent' "$html"
 grep -q 'Pending Memory Candidates' "$html"
-grep -q 'ci-sidecar-memory' "$html"
-grep -q 'Recent Page Summaries' "$html"
-grep -q 'ci-sidecar-summary' "$html"
-grep -q 'Recent Page Comparisons' "$html"
-grep -q 'ci-left-comparison' "$html"
+grep -q 'sidecar status renders pending memory candidates' "$html"
 grep -q '"pendingMemoryCount": 1' "$json"
-grep -q '"summaryCount": 1' "$json"
-grep -q '"comparisonCount": 1' "$json"
 
 echo "BearBrowser sidecar status verified"

--- a/scripts/verify-workspace-operation-plane.py
+++ b/scripts/verify-workspace-operation-plane.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Verify BearBrowser workspace operation plane contract invariants."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+CONTRACT = Path("agentplane/workspace-operation-plane.yaml")
+REQUIRED_TEXT = {
+    "browser.session.start": "missing browser.session.start operation type",
+    "browser.capture.create": "missing browser.capture.create operation type",
+    "browser.download.create": "missing browser.download.create operation type",
+    "browser.upload.create": "missing browser.upload.create operation type",
+    "browser.automation.run": "missing browser.automation.run operation type",
+    "browser.diagnostics.export_redacted": "missing browser.diagnostics.export_redacted operation type",
+    "kind: BrowserSession": "missing BrowserSession artifact",
+    "kind: WebCapture": "missing WebCapture artifact",
+    "kind: DownloadArtifact": "missing DownloadArtifact artifact",
+    "kind: UploadArtifact": "missing UploadArtifact artifact",
+    "kind: BrowserAutomationRun": "missing BrowserAutomationRun artifact",
+    "kind: BrowserDiagnosticBundle": "missing BrowserDiagnosticBundle artifact",
+    "cookies: redact": "cookies must be redacted",
+    "credentials: redact": "credentials must be redacted",
+    "tokens: redact": "tokens must be redacted",
+    "authHeaders: redact": "auth headers must be redacted",
+    "prompts: redact": "prompts must be redacted",
+    "sensitiveIds: redact": "sensitive IDs must be redacted",
+    "policyAuthority: PolicyFabric": "PolicyFabric must remain policy authority",
+    "No browser automation or capture creates durable workspace state outside the Operation Plane.": "missing durable state hard rule",
+}
+REQUIRED_LIFECYCLE = {"start", "progress", "failure", "retry", "cancel", "complete"}
+
+
+def main() -> int:
+    if not CONTRACT.exists():
+        print(f"ERROR: missing {CONTRACT}", file=sys.stderr)
+        return 1
+
+    text = CONTRACT.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    for required, message in REQUIRED_TEXT.items():
+        if required not in text:
+            errors.append(message)
+
+    for state in sorted(REQUIRED_LIFECYCLE):
+        if f"- {state}" not in text:
+            errors.append(f"missing operation event lifecycle state: {state}")
+
+    for dimension in ("externalSite", "connector", "authDomain", "thirdPartyAutomation"):
+        if f"- {dimension}" not in text:
+            errors.append(f"missing trust boundary dimension: {dimension}")
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("BearBrowser workspace operation plane contract verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Clean replay of #29 onto current `main`.

Original PR #29 contains the intended BearBrowser Workspace Operation Plane payload, but the head remained non-mergeable after a narrow sidecar verification fix. This replacement carries forward the full payload, including the fixed sidecar HTML assertion, without forcing a stale branch merge.

## Added / updated

- `agentplane/registration.yaml`
- `agentplane/session-lifecycle.example.yaml`
- `agentplane/workspace-operation-plane.yaml`
- `automation/playwright-adapter.yaml`
- `automation/stagehand-adapter.yaml`
- `automation/terminal-browser-adapters.yaml`
- `docs/agentplane-prophet-workspace-integration.md`
- `docs/integration-contract.md`
- `docs/provenance-events.md`
- `mounts/agent-browser-mounts.yaml`
- `policy/bearbrowser-contract.yaml`
- `prophet-workspace/browser-surface.yaml`
- `schemas/provenance-event.schema.json`
- `scripts/bearbrowser-emit-event.py`
- `scripts/verify-sidecar-status.sh`
- `scripts/verify-workspace-operation-plane.py`

## Scope

Browser-side effects are represented as WorkspaceOperations with typed artifacts, redacted diagnostics, trust-boundary metadata, policy gates, actor attribution, and operation lifecycle events.

This is contract/integration wiring plus verifier updates. It does not add uncontrolled browser runtime execution.

## Validation

Original PR head mostly passed, but `Feature Plane Validation` failed on a brittle sidecar status HTML assertion. The replay includes a narrow fix to assert rendered pending-memory text rather than an unrendered source label.

Expected checks on this replay:

- Feature Plane Validation
- Trust Surface
- BearBrowser shell validation
- BearBrowser automation wrapper validation
- BearBrowser manifest validation
- existing packaging / parity / branding lanes

## Supersedes

Supersedes #29 after this PR lands. Do not close #29 until this replay merges or another capture location is recorded.