### PR TITLE
packaging(cockpit): fix clean-box assemble — bun build + writable work dirs

### DIFF
--- a/scripts/build-agent-machine-sidecar.sh
+++ b/scripts/build-agent-machine-sidecar.sh
@@ -22,7 +22,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 AM_REF="${AM_REF:-main}"
 OUT="${OUT:-$REPO_ROOT/build/sidecars}"
-WORK="$REPO_ROOT/build/.agent-machine-src"
+# WORK must be WRITABLE — a package install runs this from a read-only Cellar libexec.
+WORK="${AGENT_MACHINE_WORK:-${TMPDIR:-/tmp}/bearbrowser-agent-machine-src}"
 BIN_NAME="bearbrowser-agent-machine-bin"
 AM_SUBDIR="agent-machine"
 

--- a/scripts/build-cockpit.sh
+++ b/scripts/build-cockpit.sh
@@ -21,7 +21,9 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COCKPIT_REF="${COCKPIT_REF:-master}"
 OUT="${OUT:-$REPO_ROOT/build/cockpit}"
-WORK="$REPO_ROOT/build/.cockpit-src"
+# WORK must be WRITABLE — a package install runs this from a read-only Cellar libexec,
+# so default the clone dir to TMPDIR, not $REPO_ROOT/build.
+WORK="${COCKPIT_WORK:-${TMPDIR:-/tmp}/bearbrowser-cockpit-src}"
 CLIENT_VUE_SUBDIR="socioprophet-web/client-vue"
 
 log() { printf '[build-cockpit] %s\n' "$*"; }
@@ -42,8 +44,12 @@ grep -q "resolveBase" "$SRC/src/config/cockpitRuntime.ts" 2>/dev/null \
   || { log "ERROR: cockpit source lacks the runtime resolver (needs socioprophet #468 landed)"; exit 1; }
 
 # 2. Build the static bundle ---------------------------------------------------
-log "npm ci + build in $SRC"
-( cd "$SRC" && npm ci --no-audit --no-fund && npm run build )
+# client-vue is a pnpm project (pnpm-lock.yaml, no package-lock.json) so `npm ci` can't
+# run. Build with bun instead — already required for the sidecar, fast, and it installs
+# straight from package.json regardless of which lockfile is committed.
+command -v bun >/dev/null 2>&1 || { log "ERROR: bun is required to build the cockpit. Install: brew install bun"; exit 1; }
+log "bun install + build in $SRC"
+( cd "$SRC" && bun install && bun run build )
 [ -f "$SRC/dist/index.html" ] || { log "ERROR: build produced no dist/index.html"; exit 1; }
 
 # 3. Stage into the cockpit resource dir --------------------------------------


### PR DESCRIPTION
Found by actually running `brew install` + `bearbrowser-cockpit-assemble` on a clean box (thanks to the real-machine test). Two bugs the local dev path had masked:

1. **`npm ci` on a pnpm project.** `build-cockpit.sh` ran `npm ci`, but client-vue ships `pnpm-lock.yaml` (no `package-lock.json`) — so `npm ci` bails on a fresh clone. Now builds with **bun** (already required for the sidecar; installs from `package.json` regardless of the committed lockfile). The earlier local test passed only because a stray `package-lock.json` was lying around.
2. **Read-only Cellar.** Both build scripts defaulted their clone dir to `$REPO_ROOT/build` — read-only `libexec` on a package install. Now default to `TMPDIR`.

**Verified end-to-end on the real path** — a full **fresh-clone assemble** (no local source overrides, exactly what the installed `bearbrowser-cockpit-assemble` runs): clone socioprophet → bun-build client-vue (43 files); clone noetica → bun-compile the 68M sidecar (self-smoke 200); stage. Plus a clean error if `bun` is missing.

After merge: `brew reinstall --formula sourceos-linux/tap/bearbrowser` re-fetches `main` with the fixed scripts, then `bearbrowser-cockpit-assemble && bearbrowser-cockpit-up` stands the whole thing up.